### PR TITLE
Lower required tf version

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.13.0"
+  required_version = ">= 1.11.6"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     aws = {


### PR DESCRIPTION
This is so we can use opentofu, whose latest release is 1.11.6.